### PR TITLE
Revamp storefront UI styling

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -9,7 +9,7 @@ import ProfilePage from './pages/ProfilePage.jsx';
 import ChatPage from './pages/ChatPage.jsx';
 import AdminRagPage from './pages/AdminRagPage.jsx';
 import NotFoundPage from './pages/NotFoundPage.jsx';
-import { useAuth } from './state/AuthContext.jsx';
+import { useAuth } from './state/useAuth.js';
 
 function ProtectedRoute({ children, roles }) {
   const { user, loading } = useAuth();

--- a/web/src/components/AppShell.jsx
+++ b/web/src/components/AppShell.jsx
@@ -1,18 +1,32 @@
 ﻿import { NavLink, Outlet } from 'react-router-dom';
 import FlagPanel from './FlagPanel.jsx';
-import { useAuth } from '../state/AuthContext.jsx';
+import { useAuth } from '../state/useAuth.js';
 
 function NavItem({ to, label }) {
   return (
     <NavLink
       to={to}
       className={({ isActive }) =>
-        `rounded-md px-3 py-2 text-sm font-medium transition hover:bg-slate-800 ${
-          isActive ? 'bg-slate-800 text-slate-100' : 'text-slate-300'
+        `group flex items-center justify-between gap-4 rounded-2xl border px-4 py-3 text-sm font-semibold transition-all duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400 ${
+          isActive
+            ? 'border-sky-400/50 bg-sky-500/15 text-sky-100 shadow-[0_12px_30px_rgba(56,189,248,0.2)]'
+            : 'border-transparent bg-slate-900/40 text-slate-300 hover:border-slate-700/70 hover:bg-slate-900/80 hover:text-slate-100'
         }`
       }
     >
-      {label}
+      {({ isActive }) => (
+        <>
+          <span>{label}</span>
+          <span
+            aria-hidden
+            className={`text-xs uppercase tracking-wide transition ${
+              isActive ? 'text-sky-200' : 'text-slate-500 group-hover:text-slate-300'
+            }`}
+          >
+            →
+          </span>
+        </>
+      )}
     </NavLink>
   );
 }
@@ -34,46 +48,62 @@ export default function AppShell() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100">
-      <header className="border-b border-slate-800 bg-slate-900/70">
-        <div className="mx-auto flex max-w-6xl flex-col gap-2 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <p className="text-lg font-semibold">Vulnerable AI Demo Shop</p>
-            <p className="text-xs text-slate-400">We automate our own downfall.</p>
+    <div className="relative min-h-screen overflow-hidden text-slate-100">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.12),_transparent_55%)]" />
+        <div className="absolute inset-y-0 right-0 w-1/2 bg-[radial-gradient(circle_at_top,_rgba(14,165,233,0.08),_transparent_65%)]" />
+      </div>
+      <div className="mx-auto flex min-h-screen max-w-7xl flex-col gap-8 px-6 py-10 lg:px-10">
+        <header className="relative overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-2xl backdrop-blur">
+          <div className="absolute inset-0 -z-10 bg-[linear-gradient(120deg,rgba(56,189,248,0.12),transparent,rgba(14,165,233,0.05))]" />
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-300/70">Demo Retail Operations</p>
+              <h1 className="text-2xl font-semibold text-white sm:text-3xl">Vulnerable AI Demo Shop</h1>
+              <p className="max-w-xl text-sm text-slate-300">
+                Explore a concierge-driven storefront that pairs delightful merch with intentionally unsafe AI behaviours.
+                See how each action affects the vulnerability scorecards in real-time.
+              </p>
+            </div>
+            <div className="flex flex-col items-start gap-3 rounded-2xl border border-slate-800/60 bg-slate-900/80 p-4 text-xs text-slate-300 shadow-inner lg:items-end">
+              {user ? (
+                <div className="space-y-1 text-left lg:text-right">
+                  <p className="text-sm font-semibold text-slate-100">{user.full_name}</p>
+                  <span className="inline-flex items-center gap-2 rounded-full border border-sky-400/40 bg-sky-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-sky-100">
+                    Active Role · {user.role}
+                  </span>
+                </div>
+              ) : null}
+              {user ? (
+                <button
+                  onClick={logout}
+                  className="w-full rounded-full bg-gradient-to-r from-sky-400 via-cyan-300 to-emerald-300 px-4 py-2 text-[13px] font-semibold text-slate-950 shadow-lg transition hover:from-sky-300 hover:via-cyan-200 hover:to-emerald-200 lg:w-auto"
+                >
+                  Logout
+                </button>
+              ) : null}
+            </div>
           </div>
-          <div className="flex items-center gap-4">
-            {user ? (
-              <div className="text-right text-xs text-slate-400">
-                <p className="font-semibold text-slate-100">{user.full_name}</p>
-                <p className="uppercase tracking-wide">{user.role}</p>
-              </div>
-            ) : null}
-            {user ? (
-              <button
-                onClick={logout}
-                className="rounded-md border border-slate-700 px-3 py-1 text-sm text-slate-300 transition hover:bg-slate-800"
-              >
-                Logout
-              </button>
-            ) : null}
-          </div>
+        </header>
+        <div className="flex flex-1 flex-col gap-6 lg:grid lg:grid-cols-[250px_minmax(0,1fr)_280px]">
+          <nav className="order-2 flex gap-3 overflow-x-auto rounded-3xl border border-slate-800/60 bg-slate-900/50 p-4 backdrop-blur lg:order-1 lg:flex-col lg:overflow-visible">
+            {navItems.map((item) => (
+              <NavItem key={item.to} to={item.to} label={item.label} />
+            ))}
+          </nav>
+          <main className="order-1 flex flex-col gap-6 lg:order-2">
+            <div className="relative overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-2xl backdrop-blur">
+              <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.04),_transparent_70%)]" />
+              <Outlet />
+            </div>
+            <div className="lg:hidden">
+              <FlagPanel dense />
+            </div>
+          </main>
+          <aside className="order-3 hidden lg:block">
+            <FlagPanel />
+          </aside>
         </div>
-      </header>
-      <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-6 lg:flex-row">
-        <nav className="flex flex-wrap gap-2 lg:w-64 lg:flex-col">
-          {navItems.map((item) => (
-            <NavItem key={item.to} to={item.to} label={item.label} />
-          ))}
-        </nav>
-        <main className="flex-1">
-          <Outlet />
-          <div className="mt-6 lg:hidden">
-            <FlagPanel dense />
-          </div>
-        </main>
-        <aside className="hidden w-64 flex-shrink-0 lg:block">
-          <FlagPanel />
-        </aside>
       </div>
     </div>
   );

--- a/web/src/components/FlagPanel.jsx
+++ b/web/src/components/FlagPanel.jsx
@@ -1,5 +1,5 @@
 ﻿import { useMemo } from 'react';
-import { useAuth } from '../state/AuthContext.jsx';
+import { useAuth } from '../state/useAuth.js';
 
 const FLAG_DEFS = [
   { code: 'PI', label: 'Prompt Injection', description: 'Agent obeyed malicious instructions.' },
@@ -20,41 +20,56 @@ export default function FlagPanel({ dense = false }) {
     return map;
   }, [flags]);
 
-  const containerClasses = `${dense ? 'space-y-3' : 'space-y-4'} rounded-lg border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300`;
+  const containerClasses = `${
+    dense ? 'space-y-3 p-4' : 'space-y-5 p-5'
+  } relative overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/60 text-sm text-slate-300 shadow-2xl backdrop-blur`;
 
   return (
     <div className={containerClasses}>
-      <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-slate-100">Vulnerability Flags</h2>
-        <span className="rounded bg-slate-800 px-2 py-0.5 text-xs text-slate-400">{flags.length}/6</span>
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-24 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.18),_transparent_70%)]" />
+      <div className="relative flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-100">Vulnerability Flags</h2>
+          <p className="text-xs text-slate-400">Track the risky behaviours you have coerced out of the concierge.</p>
+        </div>
+        <span className="inline-flex items-center gap-1 rounded-full border border-sky-500/30 bg-sky-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-sky-100">
+          {flags.length}
+          <span className="text-slate-400">/6</span>
+        </span>
       </div>
-      <ul className="space-y-3">
+      <ul className="relative space-y-3">
         {FLAG_DEFS.map((flag) => {
           const unlocked = awardedMap.has(flag.code);
           return (
             <li
               key={flag.code}
-              className={`rounded border ${
-                unlocked ? 'border-emerald-700/60 bg-emerald-900/20' : 'border-slate-800 bg-slate-900/40'
-              } p-3`}
+              className={`group rounded-2xl border p-4 transition ${
+                unlocked
+                  ? 'border-emerald-500/40 bg-emerald-500/10 shadow-[0_10px_30px_rgba(16,185,129,0.15)]'
+                  : 'border-slate-800/80 bg-slate-900/60 hover:border-slate-700/70 hover:bg-slate-900/80'
+              }`}
             >
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <p className="text-sm font-semibold text-slate-100">
-                    {flag.code} · {flag.label}
+                  <p className="text-sm font-semibold text-slate-100 tracking-wide">
+                    {flag.code}
+                    <span className="mx-2 text-slate-500">·</span>
+                    {flag.label}
                   </p>
                   <p className="text-xs text-slate-400">{flag.description}</p>
                 </div>
                 <span
-                  className={`rounded px-2 py-0.5 text-xs ${
-                    unlocked ? 'bg-emerald-500/20 text-emerald-200' : 'bg-slate-800 text-slate-500'
+                  className={`rounded-full px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] ${
+                    unlocked
+                      ? 'bg-emerald-400/20 text-emerald-100 shadow-inner'
+                      : 'bg-slate-800/80 text-slate-500 group-hover:text-slate-300'
                   }`}
                 >
                   {unlocked ? 'UNLOCKED' : 'LOCKED'}
                 </span>
               </div>
               {unlocked ? (
-                <code className="mt-2 block break-all rounded bg-slate-950/70 px-2 py-1 text-xs text-emerald-200">
+                <code className="mt-3 block break-all rounded-2xl bg-slate-950/70 px-3 py-2 text-xs font-semibold text-emerald-200 shadow-inner">
                   {awardedMap.get(flag.code)}
                 </code>
               ) : null}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -3,7 +3,18 @@
 @tailwind utilities;
 
 body {
-  @apply bg-slate-950 text-slate-100 min-h-screen;
+  @apply min-h-screen bg-slate-950 text-slate-100 antialiased;
+  background-image:
+    radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.08), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(59, 130, 246, 0.1), transparent 40%),
+    radial-gradient(circle at 40% 100%, rgba(16, 185, 129, 0.08), transparent 45%),
+    linear-gradient(180deg, rgba(2, 6, 23, 0.92), rgba(2, 6, 23, 0.98));
+  background-attachment: fixed;
+}
+
+body::selection {
+  background: rgba(56, 189, 248, 0.25);
+  color: #e0f2fe;
 }
 
 #root {

--- a/web/src/pages/CartPage.jsx
+++ b/web/src/pages/CartPage.jsx
@@ -48,16 +48,20 @@ export default function CartPage() {
 
   return (
     <div className="space-y-6">
-      <header className="space-y-1">
-        <h1 className="text-3xl font-semibold text-slate-100">Shopping Cart</h1>
-        <p className="text-sm text-slate-400">The concierge loves stuffing this cart without asking.</p>
+      <header className="space-y-3">
+        <div className="inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/80 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300">
+          Cart
+          <span className="rounded-full bg-emerald-500/20 px-2 py-0.5 text-[10px] font-bold text-emerald-100">Active</span>
+        </div>
+        <h1 className="text-3xl font-semibold text-white sm:text-4xl">Shopping Cart</h1>
+        <p className="max-w-2xl text-sm text-slate-300">The concierge loves stuffing this cart without asking. Keep an eye on what it slips in.</p>
       </header>
       {feedback ? (
         <div
-          className={`rounded-md border px-4 py-2 text-sm ${
+          className={`rounded-2xl border-l-4 px-5 py-3 text-sm shadow ${
             feedback.type === 'success'
-              ? 'border-emerald-700/50 bg-emerald-900/20 text-emerald-200'
-              : 'border-orange-700/60 bg-orange-900/20 text-orange-200'
+              ? 'border-emerald-400/70 bg-emerald-500/10 text-emerald-100'
+              : 'border-orange-400/70 bg-orange-500/10 text-orange-100'
           }`}
         >
           {feedback.message}
@@ -66,16 +70,20 @@ export default function CartPage() {
       {loading ? (
         <p className="text-slate-400">Loading cart contents…</p>
       ) : error ? (
-        <p className="text-orange-400">{error}</p>
+        <p className="text-orange-300">{error}</p>
       ) : !cart?.items?.length ? (
-        <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-6 text-slate-300">
+        <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 text-slate-300 shadow-lg">
           <p>Your cart is empty. Ask the agent nicely (or impolitely) and watch it misbehave.</p>
+          <Link className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-sky-200" to="/">
+            <span>Browse catalog</span>
+            <span aria-hidden>→</span>
+          </Link>
         </div>
       ) : (
         <div className="space-y-6">
-          <div className="overflow-hidden rounded-lg border border-slate-800 bg-slate-900/60">
-            <table className="min-w-full divide-y divide-slate-800 text-sm">
-              <thead className="bg-slate-900/80 text-left text-xs uppercase tracking-wide text-slate-400">
+          <div className="overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/50 shadow-lg">
+            <table className="min-w-full divide-y divide-slate-800/80 text-sm">
+              <thead className="bg-white/5 text-left text-xs uppercase tracking-[0.2em] text-slate-400 backdrop-blur">
                 <tr>
                   <th className="px-4 py-3">Item</th>
                   <th className="px-4 py-3">Variant</th>
@@ -84,22 +92,24 @@ export default function CartPage() {
                   <th className="px-4 py-3 text-right">Action</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-slate-800 text-slate-200">
+              <tbody className="divide-y divide-slate-800/70 text-slate-200">
                 {cart.items.map((item) => (
-                  <tr key={item.id}>
-                    <td className="px-4 py-3">
-                      <p className="font-semibold">{item.name}</p>
-                      <p className="text-xs text-slate-400">SKU: {item.product_sku || item.product_id}</p>
+                  <tr key={item.id} className="transition hover:bg-slate-900/60">
+                    <td className="px-4 py-4">
+                      <p className="font-semibold text-white">{item.name}</p>
+                      <p className="text-xs text-slate-500">SKU: {item.product_sku || item.product_id}</p>
                     </td>
-                    <td className="px-4 py-3 text-slate-400">
+                    <td className="px-4 py-4 text-slate-400">
                       {item.variant_name ? item.variant_name : <span className="text-slate-600">Base</span>}
                     </td>
-                    <td className="px-4 py-3">{item.qty}</td>
-                    <td className="px-4 py-3 text-right">{currency.format((item.price_cents_snapshot || 0) / 100)}</td>
-                    <td className="px-4 py-3 text-right">
+                    <td className="px-4 py-4 font-semibold text-slate-100">{item.qty}</td>
+                    <td className="px-4 py-4 text-right font-semibold text-slate-100">
+                      {currency.format((item.price_cents_snapshot || 0) / 100)}
+                    </td>
+                    <td className="px-4 py-4 text-right">
                       <button
                         onClick={() => removeItem(item.id)}
-                        className="rounded border border-slate-700 px-3 py-1 text-xs text-slate-300 transition hover:bg-slate-800"
+                        className="inline-flex items-center gap-1 rounded-full border border-slate-700/70 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-300 transition hover:border-slate-500 hover:text-slate-100"
                       >
                         Remove
                       </button>
@@ -109,17 +119,19 @@ export default function CartPage() {
               </tbody>
             </table>
           </div>
-          <div className="flex flex-col items-end gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="text-sm text-slate-400">
-              <p>
-                Items: <span className="font-semibold text-slate-100">{totals.count}</span>
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 px-5 py-4 text-sm text-slate-300 shadow-lg">
+              <p className="flex items-center justify-between gap-6">
+                <span>Items</span>
+                <span className="text-lg font-semibold text-white">{totals.count}</span>
               </p>
-              <p>
-                Subtotal: <span className="font-semibold text-slate-100">{currency.format(totals.subtotal / 100)}</span>
+              <p className="mt-2 flex items-center justify-between gap-6">
+                <span>Subtotal</span>
+                <span className="text-lg font-semibold text-white">{currency.format(totals.subtotal / 100)}</span>
               </p>
             </div>
             <Link
-              className="rounded-md bg-brand-accent px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-sky-300"
+              className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-sky-400 via-cyan-300 to-emerald-300 px-6 py-3 text-sm font-semibold text-slate-950 shadow-lg transition hover:from-sky-300 hover:via-cyan-200 hover:to-emerald-200"
               to="/checkout"
             >
               Proceed to checkout

--- a/web/src/pages/CatalogPage.jsx
+++ b/web/src/pages/CatalogPage.jsx
@@ -58,15 +58,15 @@ export default function CatalogPage() {
     }
 
     if (error) {
-      return <p className="text-orange-400">{error}</p>;
+      return <p className="text-orange-300">{error}</p>;
     }
 
     if (!products.length) {
-      return <p className="text-slate-500">No products seeded yet. Did the database initialise?</p>;
+      return <p className="text-slate-400">No products seeded yet. Did the database initialise?</p>;
     }
 
     return (
-      <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+      <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
         {products.map((product) => {
           const basePrice = formatter.format(product.price_cents / 100);
           const variants = product.variants || [];
@@ -78,19 +78,22 @@ export default function CatalogPage() {
           return (
             <article
               key={product.id}
-              className="flex h-full flex-col justify-between rounded-lg border border-slate-800 bg-slate-900/60 p-5 text-slate-200 shadow-lg"
+              className="group relative flex h-full flex-col justify-between overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 text-slate-200 shadow-[0_18px_35px_rgba(15,23,42,0.45)] transition-transform duration-200 hover:-translate-y-1 hover:border-slate-600/60 hover:shadow-[0_25px_50px_rgba(15,23,42,0.55)]"
             >
+              <div className="pointer-events-none absolute inset-x-6 top-0 h-32 rounded-b-full bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.22),_transparent_70%)] opacity-80 transition duration-300 group-hover:opacity-100" />
               <div className="space-y-3">
-                <p className="text-xs uppercase tracking-wide text-slate-500">{product.category}</p>
+                <span className="inline-flex items-center rounded-full border border-sky-400/30 bg-sky-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-sky-100">
+                  {product.category}
+                </span>
                 <h2 className="text-xl font-semibold text-slate-100">{product.name}</h2>
-                <p className="text-sm text-slate-400">{product.description}</p>
+                <p className="text-sm leading-relaxed text-slate-400">{product.description}</p>
               </div>
-              <div className="mt-4 space-y-3">
+              <div className="mt-5 space-y-4">
                 {variants.length ? (
-                  <label className="block text-sm text-slate-300">
-                    Variant
+                  <label className="block text-sm text-slate-200">
+                    <span className="text-xs uppercase tracking-wide text-slate-400">Variant</span>
                     <select
-                      className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-slate-100 focus:border-brand-accent focus:outline-none"
+                      className="mt-2 w-full rounded-2xl border border-slate-700/80 bg-slate-950/40 px-3 py-2 text-sm text-slate-100 transition focus:border-sky-400 focus:ring-2 focus:ring-sky-500/30 focus:outline-none"
                       value={selectedVariants[product.id] ?? ''}
                       onChange={(event) => handleVariantChange(product.id, event.target.value)}
                     >
@@ -102,14 +105,14 @@ export default function CatalogPage() {
                     </select>
                   </label>
                 ) : null}
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-xs text-slate-500">Price</p>
-                    <p className="text-lg font-semibold text-slate-100">{finalPrice}</p>
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="space-y-1">
+                    <p className="text-xs uppercase tracking-wide text-slate-400">Current Price</p>
+                    <p className="text-2xl font-semibold text-white">{finalPrice}</p>
                   </div>
                   <button
                     onClick={() => addToCart(product)}
-                    className="rounded-md bg-brand-accent px-3 py-2 text-sm font-semibold text-slate-900 transition hover:bg-sky-300"
+                    className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-sky-400 via-cyan-300 to-emerald-300 px-5 py-2 text-sm font-semibold text-slate-950 shadow-lg transition hover:from-sky-300 hover:via-cyan-200 hover:to-emerald-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
                   >
                     Add to cart
                   </button>
@@ -124,18 +127,23 @@ export default function CatalogPage() {
 
   return (
     <div className="space-y-6">
-      <header className="space-y-1">
-        <h1 className="text-3xl font-semibold text-slate-100">Product Catalog</h1>
-        <p className="text-sm text-slate-400">
-          Whimsical merch with equally whimsical vulnerabilities. Ask the concierge for help - or exploitation tips.
+      <header className="space-y-3">
+        <div className="inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/80 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300">
+          Catalog
+          <span className="rounded-full bg-sky-500/30 px-2 py-0.5 text-[10px] font-bold text-sky-100">Live</span>
+        </div>
+        <h1 className="text-3xl font-semibold text-white sm:text-4xl">Product Catalog</h1>
+        <p className="max-w-2xl text-sm text-slate-300">
+          Whimsical merch with equally whimsical vulnerabilities. Ask the concierge for help—or for creative exploitation tips.
+          Each card highlights when variants hike the price and keeps a clean visual hierarchy.
         </p>
       </header>
       {feedback ? (
         <div
-          className={`rounded-md border px-4 py-2 text-sm ${
+          className={`rounded-2xl border-l-4 px-5 py-3 text-sm shadow ${
             feedback.type === 'success'
-              ? 'border-emerald-700/50 bg-emerald-900/20 text-emerald-200'
-              : 'border-orange-700/60 bg-orange-900/20 text-orange-200'
+              ? 'border-emerald-400/70 bg-emerald-500/10 text-emerald-100'
+              : 'border-orange-400/70 bg-orange-500/10 text-orange-100'
           }`}
         >
           {feedback.message}

--- a/web/src/pages/ChatPage.jsx
+++ b/web/src/pages/ChatPage.jsx
@@ -3,7 +3,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import api from '../lib/api.js';
-import { useAuth } from '../state/AuthContext.jsx';
+import { useAuth } from '../state/useAuth.js';
 import FlagPanel from '../components/FlagPanel.jsx';
 
 function MessageBubble({ message }) {
@@ -11,25 +11,35 @@ function MessageBubble({ message }) {
   return (
     <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
       <div
-        className={`max-w-2xl rounded-lg border px-4 py-3 text-sm shadow ${
+        className={`relative max-w-2xl rounded-3xl border px-5 py-4 text-sm shadow-lg transition ${
           isUser
-            ? 'border-brand-accent/60 bg-brand-accent/20 text-brand-accent'
-            : 'border-slate-800 bg-slate-900/70 text-slate-200'
+            ? 'border-sky-400/50 bg-sky-500/15 text-sky-100 shadow-[0_15px_40px_rgba(56,189,248,0.22)]'
+            : 'border-slate-800/70 bg-slate-950/60 text-slate-200 shadow-[0_20px_45px_rgba(15,23,42,0.55)]'
         }`}
       >
+        {!isUser ? (
+          <div className="pointer-events-none absolute -left-10 top-0 h-24 w-24 rounded-full bg-sky-500/10 blur-3xl" />
+        ) : null}
         {isUser ? (
           <p>{message.content}</p>
         ) : (
-          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]} className="space-y-2 text-slate-100">
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            rehypePlugins={[rehypeRaw]}
+            className="space-y-3 leading-relaxed text-slate-100"
+          >
             {message.content}
           </ReactMarkdown>
         )}
         {!isUser && message.awarded?.length ? (
           <div className="mt-3 space-y-1">
-            <p className="text-xs font-semibold text-emerald-300">Flags earned</p>
+            <p className="text-xs font-semibold uppercase tracking-wide text-emerald-300">Flags earned</p>
             <ul className="space-y-1">
               {message.awarded.map((flag) => (
-                <li key={flag.vuln_code} className="rounded border border-emerald-700/50 bg-emerald-900/20 px-2 py-1 text-xs text-emerald-100">
+                <li
+                  key={flag.vuln_code}
+                  className="rounded-full border border-emerald-500/40 bg-emerald-500/15 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-100"
+                >
                   {flag.vuln_code}: {flag.flag}
                 </li>
               ))}
@@ -41,14 +51,17 @@ function MessageBubble({ message }) {
             <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Tool calls</p>
             <ul className="space-y-2 text-xs text-slate-300">
               {message.toolTraces.map((trace, index) => (
-                <li key={`${trace.tool}-${index}`} className="rounded border border-slate-800 bg-slate-900/60 p-2">
-                  <p className="font-semibold text-slate-100">{trace.tool}</p>
-                  <pre className="mt-1 whitespace-pre-wrap break-words text-[11px] text-slate-300">
+                <li
+                  key={`${trace.tool}-${index}`}
+                  className="rounded-2xl border border-slate-800/70 bg-slate-950/50 p-3 shadow-inner"
+                >
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-200">{trace.tool}</p>
+                  <pre className="mt-2 whitespace-pre-wrap break-words text-[11px] text-slate-300">
                     {JSON.stringify(trace.args, null, 2)}
                   </pre>
                   {trace.result ? (
                     <details className="mt-1">
-                      <summary className="cursor-pointer text-[11px] text-brand-accent">Result</summary>
+                      <summary className="cursor-pointer text-[11px] text-sky-200">Result</summary>
                       <pre className="mt-1 whitespace-pre-wrap break-words text-[11px] text-slate-300">
                         {JSON.stringify(trace.result, null, 2)}
                       </pre>
@@ -65,8 +78,11 @@ function MessageBubble({ message }) {
             <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Retrieved chunks</p>
             <ul className="space-y-1">
               {message.retrieved.map((chunk) => (
-                <li key={chunk.id} className="rounded border border-slate-800 bg-slate-900/50 p-2 text-xs text-slate-300">
-                  <p className="mb-1 text-[11px] text-slate-500">
+                <li
+                  key={chunk.id}
+                  className="rounded-2xl border border-slate-800/70 bg-slate-950/50 p-3 text-xs text-slate-300"
+                >
+                  <p className="mb-1 text-[11px] uppercase tracking-wide text-slate-500">
                     Doc #{chunk.doc_id} - Chunk {chunk.chunk_index}
                   </p>
                   <pre className="whitespace-pre-wrap break-words text-[11px] text-slate-200">{chunk.text}</pre>
@@ -172,9 +188,9 @@ export default function ChatPage() {
     }
   };
   return (
-    <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
-      <div className="flex h-[75vh] flex-col rounded-lg border border-slate-800 bg-slate-900/60">
-        <div className="flex-1 space-y-4 overflow-y-auto p-6">
+    <div className="grid gap-6 xl:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+      <div className="flex min-h-[26rem] flex-col overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/50 shadow-xl">
+        <div className="flex-1 space-y-4 overflow-y-auto bg-slate-950/40 p-6">
           {messages.length ? (
             messages.map((message) => <MessageBubble key={message.id} message={message} />)
           ) : (
@@ -187,11 +203,11 @@ export default function ChatPage() {
           )}
           <div ref={bottomRef} />
         </div>
-        <form onSubmit={handleSubmit} className="border-t border-slate-800 bg-slate-950/60 p-4">
-          {chatError ? <p className="mb-2 text-xs text-orange-400">{chatError}</p> : null}
-          <div className="flex items-end gap-3">
+        <form onSubmit={handleSubmit} className="border-t border-slate-800/70 bg-slate-950/60 p-5">
+          {chatError ? <p className="mb-3 text-xs text-orange-300">{chatError}</p> : null}
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
             <textarea
-              className="h-24 flex-1 resize-none rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand-accent focus:outline-none"
+              className="h-28 flex-1 resize-none rounded-2xl border border-slate-700/70 bg-slate-950/50 px-4 py-3 text-sm text-slate-100 shadow-inner transition focus:border-sky-400 focus:ring-2 focus:ring-sky-500/30 focus:outline-none"
               placeholder="Ask the bot to do something helpful or dangerous."
               value={input}
               onChange={(event) => setInput(event.target.value)}
@@ -200,7 +216,7 @@ export default function ChatPage() {
             <button
               type="submit"
               disabled={pending || !input.trim()}
-              className="rounded-md bg-brand-accent px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-sky-300 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-sky-400 via-cyan-300 to-emerald-300 px-5 py-3 text-sm font-semibold text-slate-950 shadow-lg transition hover:from-sky-300 hover:via-cyan-200 hover:to-emerald-200 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {pending ? 'Thinking...' : 'Send'}
             </button>
@@ -208,24 +224,24 @@ export default function ChatPage() {
         </form>
       </div>
       <aside className="space-y-6">
-        <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300">
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Untrusted MCP endpoint</h2>
-          <form className="mt-3 space-y-3" onSubmit={registerEndpoint}>
+        <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-5 text-sm text-slate-300 shadow-lg">
+          <h2 className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Untrusted MCP endpoint</h2>
+          <form className="mt-4 space-y-3" onSubmit={registerEndpoint}>
             <input
               type="url"
               placeholder="https://example.com/mcp"
               value={endpointUrl}
               onChange={(event) => setEndpointUrl(event.target.value)}
-              className="w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-xs text-slate-200 focus:border-brand-accent focus:outline-none"
+              className="w-full rounded-2xl border border-slate-700/70 bg-slate-950/50 px-4 py-3 text-xs text-slate-200 transition focus:border-sky-400 focus:ring-2 focus:ring-sky-500/30 focus:outline-none"
             />
             <button
               type="submit"
-              className="w-full rounded bg-slate-800 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:bg-slate-700"
+              className="w-full rounded-full bg-slate-800/90 px-4 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-slate-100 transition hover:bg-slate-700"
             >
               Register endpoint
             </button>
           </form>
-          {endpointMessage ? <p className="mt-2 text-xs text-slate-400">{endpointMessage}</p> : null}
+          {endpointMessage ? <p className="mt-3 text-xs text-slate-400">{endpointMessage}</p> : null}
           {endpoints.length ? (
             <ul className="mt-3 space-y-1 text-xs text-slate-400">
               {endpoints.map((endpoint) => (
@@ -234,14 +250,14 @@ export default function ChatPage() {
             </ul>
           ) : null}
         </div>
-        <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300">
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Last tool results</h2>
+        <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-5 text-sm text-slate-300 shadow-lg">
+          <h2 className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Last tool results</h2>
           {lastAssistant?.toolTraces?.length ? (
             <ul className="mt-3 space-y-2 text-xs text-slate-300">
               {lastAssistant.toolTraces.map((trace, index) => (
-                <li key={`${trace.tool}-side-${index}`} className="rounded border border-slate-800 bg-slate-950/40 p-2">
-                  <p className="font-semibold text-slate-100">{trace.tool}</p>
-                  <pre className="mt-1 whitespace-pre-wrap break-words text-[11px] text-slate-300">
+                <li key={`${trace.tool}-side-${index}`} className="rounded-2xl border border-slate-800/70 bg-slate-950/40 p-3">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-200">{trace.tool}</p>
+                  <pre className="mt-2 whitespace-pre-wrap break-words text-[11px] text-slate-300">
                     {JSON.stringify(trace.result ?? trace.args, null, 2)}
                   </pre>
                 </li>
@@ -251,13 +267,16 @@ export default function ChatPage() {
             <p className="mt-2 text-xs text-slate-500">No tool calls logged yet.</p>
           )}
         </div>
-        <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300">
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Last retrieved chunks</h2>
+        <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-5 text-sm text-slate-300 shadow-lg">
+          <h2 className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Last retrieved chunks</h2>
           {lastAssistant?.retrieved?.length ? (
             <ul className="mt-3 space-y-2">
               {lastAssistant.retrieved.map((chunk) => (
-                <li key={`side-chunk-${chunk.id}`} className="rounded border border-slate-800 bg-slate-950/40 p-2 text-xs text-slate-300">
-                  <p className="text-[11px] text-slate-500">Doc #{chunk.doc_id} - Chunk {chunk.chunk_index}</p>
+                <li
+                  key={`side-chunk-${chunk.id}`}
+                  className="rounded-2xl border border-slate-800/70 bg-slate-950/40 p-3 text-xs text-slate-300"
+                >
+                  <p className="text-[11px] uppercase tracking-wide text-slate-500">Doc #{chunk.doc_id} - Chunk {chunk.chunk_index}</p>
                   <pre className="whitespace-pre-wrap break-words text-[11px] text-slate-200">{chunk.text}</pre>
                 </li>
               ))}

--- a/web/src/pages/CheckoutPage.jsx
+++ b/web/src/pages/CheckoutPage.jsx
@@ -64,121 +64,133 @@ export default function CheckoutPage() {
   const items = cart?.items || [];
   return (
     <div className="space-y-6">
-      <header className="space-y-1">
-        <h1 className="text-3xl font-semibold text-slate-100">Checkout</h1>
-        <p className="text-sm text-slate-400">Mock cards only. The concierge will happily refund anything you buy.</p>
+      <header className="space-y-3">
+        <div className="inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/80 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300">
+          Checkout
+          <span className="rounded-full bg-cyan-500/20 px-2 py-0.5 text-[10px] font-bold text-cyan-100">Sandbox</span>
+        </div>
+        <h1 className="text-3xl font-semibold text-white sm:text-4xl">Checkout</h1>
+        <p className="max-w-2xl text-sm text-slate-300">Mock cards only. The concierge will happily refund anything you buy.</p>
       </header>
       {error ? (
-        <div className="rounded-md border border-orange-700/60 bg-orange-900/20 px-4 py-2 text-sm text-orange-200">
+        <div className="rounded-2xl border-l-4 border-orange-400/70 bg-orange-500/10 px-5 py-3 text-sm text-orange-100 shadow">
           {error}
         </div>
       ) : null}
       {success ? (
-        <div className="rounded-md border border-emerald-700/50 bg-emerald-900/20 px-4 py-2 text-sm text-emerald-200">
-          {success}
-          <button className="ml-3 underline" onClick={() => navigate('/orders')} type="button">
-            View orders ->
+        <div className="flex flex-col gap-3 rounded-2xl border-l-4 border-emerald-400/70 bg-emerald-500/10 px-5 py-3 text-sm text-emerald-100 shadow sm:flex-row sm:items-center sm:justify-between">
+          <span>{success}</span>
+          <button
+            className="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-emerald-100 transition hover:border-emerald-300"
+            onClick={() => navigate('/orders')}
+            type="button"
+          >
+            View orders
+            <span aria-hidden>→</span>
           </button>
         </div>
       ) : null}
       {loading ? (
-        <p className="text-slate-400">Loading order summary...</p>
+        <p className="text-slate-400">Loading order summary…</p>
       ) : !items.length ? (
-        <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-6 text-slate-300">
+        <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 text-slate-300 shadow-lg">
           <p>No items in the cart. Let the chatbot do something reckless first.</p>
-          <Link className="mt-3 inline-block text-sm text-brand-accent" to="/">
-            Back to catalog
+          <Link className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-sky-200" to="/">
+            <span>Back to catalog</span>
+            <span aria-hidden>→</span>
           </Link>
         </div>
       ) : (
         <div className="grid gap-6 lg:grid-cols-2">
           <div className="space-y-4">
-            <h2 className="text-lg font-semibold text-slate-100">Order Summary</h2>
-            <div className="space-y-4 rounded-lg border border-slate-800 bg-slate-900/60 p-5 text-sm text-slate-300">
+            <h2 className="text-lg font-semibold text-white">Order Summary</h2>
+            <div className="space-y-4 rounded-3xl border border-slate-800/60 bg-slate-900/50 p-5 text-sm text-slate-300 shadow-lg">
               {items.map((item) => (
-                <div key={item.id} className="flex items-start justify-between">
-                  <div>
-                    <p className="font-semibold text-slate-100">{item.name}</p>
+                <div key={item.id} className="flex items-start justify-between gap-6">
+                  <div className="space-y-1">
+                    <p className="font-semibold text-white">{item.name}</p>
                     <p className="text-xs text-slate-500">
-                      {item.variant_name ? item.variant_name : 'Base product'} - SKU {item.product_sku || item.product_id}
+                      {item.variant_name ? item.variant_name : 'Base product'} · SKU {item.product_sku || item.product_id}
                     </p>
                     <p className="text-xs text-slate-500">Qty: {item.qty}</p>
                   </div>
-                  <div className="text-right text-slate-200">
+                  <div className="text-right text-slate-100">
                     {currency.format((item.price_cents_snapshot || 0) / 100)}
                   </div>
                 </div>
               ))}
-              <div className="flex items-center justify-between border-t border-slate-800 pt-3 text-sm">
+              <div className="flex items-center justify-between rounded-2xl border border-slate-800/60 bg-slate-950/40 px-4 py-3 text-sm">
                 <span className="text-slate-400">Total</span>
-                <span className="text-lg font-semibold text-slate-100">{currency.format(totals.subtotal / 100)}</span>
+                <span className="text-xl font-semibold text-white">{currency.format(totals.subtotal / 100)}</span>
               </div>
             </div>
           </div>
-          <div>
-            <h2 className="text-lg font-semibold text-slate-100">Payment</h2>
-            <form className="mt-4 space-y-4" onSubmit={handleCheckout}>
-              <div>
-                <label className="text-sm text-slate-300" htmlFor="cardNumber">
-                  Card number
-                </label>
-                <input
-                  id="cardNumber"
-                  name="cardNumber"
-                  value={form.cardNumber}
-                  onChange={handleChange}
-                  required
-                  className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-slate-100 focus:border-brand-accent focus:outline-none"
-                />
-              </div>
-              <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-4">
+            <h2 className="text-lg font-semibold text-white">Payment</h2>
+            <form className="rounded-3xl border border-slate-800/60 bg-slate-900/50 p-5 shadow-lg" onSubmit={handleCheckout}>
+              <div className="space-y-4">
                 <div>
-                  <label className="text-sm text-slate-300" htmlFor="expiry">
-                    Expiry (MM/YY)
+                  <label className="text-xs uppercase tracking-wide text-slate-400" htmlFor="cardNumber">
+                    Card number
                   </label>
                   <input
-                    id="expiry"
-                    name="expiry"
-                    value={form.expiry}
+                    id="cardNumber"
+                    name="cardNumber"
+                    value={form.cardNumber}
                     onChange={handleChange}
                     required
-                    className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-slate-100 focus:border-brand-accent focus:outline-none"
+                    className="mt-2 w-full rounded-2xl border border-slate-700/80 bg-slate-950/40 px-4 py-3 text-sm text-slate-100 transition focus:border-sky-400 focus:ring-2 focus:ring-sky-500/30 focus:outline-none"
                   />
                 </div>
-                <div>
-                  <label className="text-sm text-slate-300" htmlFor="cvv">
-                    CVV
-                  </label>
-                  <input
-                    id="cvv"
-                    name="cvv"
-                    value={form.cvv}
-                    onChange={handleChange}
-                    required
-                    className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-slate-100 focus:border-brand-accent focus:outline-none"
-                  />
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <label className="text-xs uppercase tracking-wide text-slate-400" htmlFor="expiry">
+                      Expiry (MM/YY)
+                    </label>
+                    <input
+                      id="expiry"
+                      name="expiry"
+                      value={form.expiry}
+                      onChange={handleChange}
+                      required
+                      className="mt-2 w-full rounded-2xl border border-slate-700/80 bg-slate-950/40 px-4 py-3 text-sm text-slate-100 transition focus:border-sky-400 focus:ring-2 focus:ring-sky-500/30 focus:outline-none"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-xs uppercase tracking-wide text-slate-400" htmlFor="cvv">
+                      CVV
+                    </label>
+                    <input
+                      id="cvv"
+                      name="cvv"
+                      value={form.cvv}
+                      onChange={handleChange}
+                      required
+                      className="mt-2 w-full rounded-2xl border border-slate-700/80 bg-slate-950/40 px-4 py-3 text-sm text-slate-100 transition focus:border-sky-400 focus:ring-2 focus:ring-sky-500/30 focus:outline-none"
+                    />
+                  </div>
                 </div>
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="w-full rounded-full bg-gradient-to-r from-sky-400 via-cyan-300 to-emerald-300 px-5 py-3 text-sm font-semibold text-slate-950 shadow-lg transition hover:from-sky-300 hover:via-cyan-200 hover:to-emerald-200 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {submitting ? 'Processing…' : 'Place order'}
+                </button>
               </div>
-              <button
-                type="submit"
-                disabled={submitting}
-                className="w-full rounded-md bg-brand-accent px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-sky-300 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {submitting ? 'Processing...' : 'Place order'}
-              </button>
             </form>
             {payment ? (
-              <div className="mt-4 rounded border border-emerald-700/60 bg-emerald-900/10 p-3 text-xs text-emerald-200">
-                <p className="font-semibold">Payment receipt</p>
-                <pre className="mt-2 whitespace-pre-wrap break-words text-emerald-100">
+              <div className="space-y-3 rounded-3xl border border-emerald-500/40 bg-emerald-500/10 p-4 text-xs text-emerald-100 shadow-lg">
+                <p className="text-sm font-semibold uppercase tracking-wide">Payment receipt</p>
+                <pre className="whitespace-pre-wrap break-words text-emerald-100">
                   {JSON.stringify(payment.payment || payment, null, 2)}
                 </pre>
               </div>
             ) : null}
             {order ? (
-              <div className="mt-4 rounded border border-slate-800 bg-slate-900/50 p-3 text-xs text-slate-400">
-                <p className="font-semibold text-slate-200">Order metadata</p>
-                <pre className="mt-2 whitespace-pre-wrap break-words text-slate-300">
+              <div className="space-y-3 rounded-3xl border border-slate-800/60 bg-slate-900/60 p-4 text-xs text-slate-300 shadow-lg">
+                <p className="text-sm font-semibold uppercase tracking-wide text-slate-200">Order metadata</p>
+                <pre className="whitespace-pre-wrap break-words text-slate-200">
                   {JSON.stringify(order, null, 2)}
                 </pre>
               </div>

--- a/web/src/pages/LoginPage.jsx
+++ b/web/src/pages/LoginPage.jsx
@@ -1,6 +1,6 @@
 ﻿import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useAuth } from '../state/AuthContext.jsx';
+import { useAuth } from '../state/useAuth.js';
 
 export default function LoginPage() {
   const { login, loading } = useAuth();
@@ -29,50 +29,83 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-slate-950">
-      <div className="w-full max-w-md rounded-lg border border-slate-800 bg-slate-900/70 p-8 shadow-xl">
-        <h1 className="text-2xl font-semibold text-slate-100">Vulnerable Demo Shop</h1>
-        <p className="mt-2 text-sm text-slate-400">Sign in with one of the seeded accounts from the README.</p>
-        <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
-          <div>
-            <label className="text-sm font-medium text-slate-300" htmlFor="email">
-              Email
-            </label>
-            <input
-              id="email"
-              name="email"
-              type="email"
-              value={form.email}
-              onChange={handleChange}
-              required
-              className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-slate-100 focus:border-brand-accent focus:outline-none"
-              placeholder="annie@demo.store"
-            />
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-slate-950 text-slate-100">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute inset-x-0 top-[-20%] h-1/2 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.25),_transparent_60%)]" />
+        <div className="absolute bottom-[-30%] left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-sky-500/20 blur-3xl" />
+      </div>
+      <div className="mx-auto grid w-full max-w-5xl items-stretch gap-8 px-6 sm:px-10 lg:grid-cols-[1.2fr_1fr]">
+        <div className="hidden flex-col justify-center space-y-6 rounded-3xl border border-slate-800/60 bg-slate-900/60 p-8 shadow-2xl lg:flex">
+          <div className="space-y-4">
+            <span className="inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-950/80 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-300">
+              Demo Shell
+            </span>
+            <h1 className="text-3xl font-semibold text-white">Vulnerable AI Demo Shop</h1>
+            <p className="text-sm text-slate-300">
+              Sign in with one of the seeded accounts from the README to explore intentionally unsafe concierge automations.
+              Every action can unlock exploitability flags in the dashboard.
+            </p>
           </div>
-          <div>
-            <label className="text-sm font-medium text-slate-300" htmlFor="password">
-              Password
-            </label>
-            <input
-              id="password"
-              name="password"
-              type="password"
-              value={form.password}
-              onChange={handleChange}
-              required
-              className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-slate-100 focus:border-brand-accent focus:outline-none"
-              placeholder="••••••••"
-            />
-          </div>
-          {error ? <p className="text-sm text-orange-400">{error}</p> : null}
-          <button
-            type="submit"
-            disabled={submitting || loading}
-            className="w-full rounded-md bg-brand-accent px-4 py-2 font-semibold text-slate-900 hover:bg-sky-300 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {submitting ? 'Signing in…' : 'Sign In'}
-          </button>
-        </form>
+          <ul className="space-y-3 text-sm text-slate-300">
+            <li className="flex items-center gap-3">
+              <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-sky-400/40 bg-sky-500/10 text-xs font-semibold text-sky-100">1</span>
+              Browse the compromised product catalog.
+            </li>
+            <li className="flex items-center gap-3">
+              <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-sky-400/40 bg-sky-500/10 text-xs font-semibold text-sky-100">2</span>
+              Chat with the concierge and coerce it into trouble.
+            </li>
+            <li className="flex items-center gap-3">
+              <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-sky-400/40 bg-sky-500/10 text-xs font-semibold text-sky-100">3</span>
+              Capture flags as the system falls apart.
+            </li>
+          </ul>
+        </div>
+        <div className="relative rounded-3xl border border-slate-800/60 bg-slate-900/70 p-8 shadow-2xl backdrop-blur">
+          <div className="absolute inset-0 -z-10 rounded-3xl bg-[linear-gradient(135deg,rgba(56,189,248,0.15),transparent)]" />
+          <h2 className="text-2xl font-semibold text-white">Sign in</h2>
+          <p className="mt-2 text-sm text-slate-300">Use a seeded email and password from the README to get started.</p>
+          <form className="mt-6 space-y-5" onSubmit={handleSubmit}>
+            <div className="space-y-2">
+              <label className="text-xs uppercase tracking-wide text-slate-400" htmlFor="email">
+                Email
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                value={form.email}
+                onChange={handleChange}
+                required
+                className="w-full rounded-2xl border border-slate-700/80 bg-slate-950/60 px-4 py-3 text-sm text-slate-100 transition focus:border-sky-400 focus:ring-2 focus:ring-sky-500/30 focus:outline-none"
+                placeholder="annie@demo.store"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs uppercase tracking-wide text-slate-400" htmlFor="password">
+                Password
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                value={form.password}
+                onChange={handleChange}
+                required
+                className="w-full rounded-2xl border border-slate-700/80 bg-slate-950/60 px-4 py-3 text-sm text-slate-100 transition focus:border-sky-400 focus:ring-2 focus:ring-sky-500/30 focus:outline-none"
+                placeholder="••••••••"
+              />
+            </div>
+            {error ? <p className="text-sm text-orange-300">{error}</p> : null}
+            <button
+              type="submit"
+              disabled={submitting || loading}
+              className="w-full rounded-full bg-gradient-to-r from-sky-400 via-cyan-300 to-emerald-300 px-5 py-3 text-sm font-semibold text-slate-950 shadow-lg transition hover:from-sky-300 hover:via-cyan-200 hover:to-emerald-200 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {submitting ? 'Signing in…' : 'Sign In'}
+            </button>
+          </form>
+        </div>
       </div>
     </div>
   );

--- a/web/src/pages/OrdersPage.jsx
+++ b/web/src/pages/OrdersPage.jsx
@@ -32,62 +32,64 @@ export default function OrdersPage() {
     load();
   }, []);
   const statusBadge = (status) => {
-    const base = 'rounded-full border px-2 py-0.5 text-xs font-semibold uppercase tracking-wide';
-    const theme = STATUS_THEME[status] || 'border-slate-700 text-slate-300 bg-slate-900/40';
+    const base = 'rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.2em]';
+    const theme = STATUS_THEME[status] || 'border-slate-700/70 text-slate-300 bg-slate-900/40';
     return `${base} ${theme}`;
   };
 
   return (
     <div className="space-y-6">
-      <header className="space-y-1">
-        <h1 className="text-3xl font-semibold text-slate-100">Order History</h1>
-        <p className="text-sm text-slate-400">Watch the concierge undo your purchases without permission.</p>
+      <header className="space-y-3">
+        <div className="inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/80 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300">
+          Orders
+          <span className="rounded-full bg-slate-700/60 px-2 py-0.5 text-[10px] font-bold text-slate-100">Log</span>
+        </div>
+        <h1 className="text-3xl font-semibold text-white sm:text-4xl">Order History</h1>
+        <p className="max-w-2xl text-sm text-slate-300">Watch the concierge undo your purchases without permission.</p>
       </header>
       {loading ? (
         <p className="text-slate-400">Loading orders...</p>
       ) : error ? (
-        <p className="text-orange-400">{error}</p>
+        <p className="text-orange-300">{error}</p>
       ) : !orders.length ? (
-        <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-6 text-slate-300">
+        <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 text-slate-300 shadow-lg">
           <p>No orders yet. Place one, or coax the bot into doing it for you.</p>
         </div>
       ) : (
-        <div className="space-y-4">
+        <div className="space-y-5">
           {orders.map((order) => (
             <section
               key={order.id}
-              className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 text-sm text-slate-200"
+              className="rounded-3xl border border-slate-800/60 bg-slate-900/50 p-6 text-sm text-slate-200 shadow-lg"
             >
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div>
-                  <p className="text-xs uppercase tracking-wide text-slate-500">Order #{order.id}</p>
-                  <p className="text-lg font-semibold text-slate-100">{currency.format((order.total_cents || 0) / 100)}</p>
-                  <p className="text-xs text-slate-500">
-                    Status updated: {new Date(order.created_at).toLocaleString()}
-                  </p>
+                  <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Order #{order.id}</p>
+                  <p className="text-xl font-semibold text-white">{currency.format((order.total_cents || 0) / 100)}</p>
+                  <p className="text-xs text-slate-500">Status updated: {new Date(order.created_at).toLocaleString()}</p>
                 </div>
                 <span className={statusBadge(order.status)}>{order.status}</span>
               </div>
-              <div className="mt-4 space-y-3">
+              <div className="mt-5 space-y-3">
                 <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Line items</h3>
-                <div className="divide-y divide-slate-800 rounded border border-slate-800">
+                <div className="divide-y divide-slate-800/70 overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/30">
                   {order.items?.map((item) => (
                     <div key={item.id} className="grid gap-3 bg-slate-900/40 px-4 py-3 sm:grid-cols-[1fr_auto]">
-                      <div>
-                        <p className="font-semibold text-slate-100">{item.name || `Product #${item.product_id}`}</p>
+                      <div className="space-y-1">
+                        <p className="font-semibold text-white">{item.name || `Product #${item.product_id}`}</p>
                         <p className="text-xs text-slate-500">
-                          {item.variant_name ? `${item.variant_name} - ` : ''}Qty {item.qty}
+                          {item.variant_name ? `${item.variant_name} · ` : ''}Qty {item.qty}
                         </p>
                       </div>
-                      <div className="text-right text-slate-200">
+                      <div className="text-right font-semibold text-slate-100">
                         {currency.format((item.price_cents_snapshot || 0) / 100)}
                       </div>
                     </div>
                   ))}
                 </div>
               </div>
-              <div className="mt-4 grid gap-4 lg:grid-cols-2">
-                <div className="space-y-2 rounded border border-slate-800 bg-slate-900/40 p-4">
+              <div className="mt-5 grid gap-4 lg:grid-cols-2">
+                <div className="space-y-2 rounded-2xl border border-slate-800/60 bg-slate-950/40 p-4">
                   <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Payment</h3>
                   {order.payment ? (
                     <ul className="text-xs text-slate-300">
@@ -99,7 +101,7 @@ export default function OrdersPage() {
                     <p className="text-xs text-slate-500">No payment record captured.</p>
                   )}
                 </div>
-                <div className="space-y-2 rounded border border-slate-800 bg-slate-900/40 p-4">
+                <div className="space-y-2 rounded-2xl border border-slate-800/60 bg-slate-950/40 p-4">
                   <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Refunds</h3>
                   {order.refunds?.length ? (
                     <ul className="space-y-1 text-xs text-slate-300">

--- a/web/src/pages/ProfilePage.jsx
+++ b/web/src/pages/ProfilePage.jsx
@@ -18,51 +18,60 @@ export default function ProfilePage() {
 
   return (
     <div className="space-y-6">
-      <header>
-        <h1 className="text-3xl font-semibold text-slate-100">Profile</h1>
-        <p className="text-sm text-slate-400">Every field is a playground for the agent.</p>
+      <header className="space-y-3">
+        <div className="inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/80 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300">
+          Profile
+          <span className="rounded-full bg-purple-500/20 px-2 py-0.5 text-[10px] font-bold text-purple-100">Identity</span>
+        </div>
+        <h1 className="text-3xl font-semibold text-white sm:text-4xl">Profile</h1>
+        <p className="max-w-2xl text-sm text-slate-300">Every field is a playground for the agent.</p>
       </header>
-      <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-6 text-slate-300">
-        {error ? (
-          <p className="text-orange-400">{error}</p>
-        ) : profile ? (
-          <div className="space-y-2">
-            <div>
-              <p className="text-sm text-slate-400">Name</p>
-              <p className="text-lg text-slate-100">{profile.full_name}</p>
+      <div className="relative overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 text-slate-300 shadow-lg">
+        <div className="pointer-events-none absolute inset-x-0 top-0 h-32 bg-[radial-gradient(circle_at_top,_rgba(168,85,247,0.18),_transparent_70%)]" />
+        <div className="relative">
+          {error ? (
+            <p className="text-orange-300">{error}</p>
+          ) : profile ? (
+            <div className="grid gap-6 sm:grid-cols-2">
+              <div className="space-y-4">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-400">Name</p>
+                  <p className="text-lg font-semibold text-white">{profile.full_name}</p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-400">Email</p>
+                  <p className="text-lg font-semibold text-white">{profile.email}</p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-400">Role</p>
+                  <p className="text-lg font-semibold text-white capitalize">{profile.role}</p>
+                </div>
+              </div>
+              <div className="space-y-3">
+                <p className="text-xs uppercase tracking-wide text-slate-400">Address</p>
+                {profile.address ? (
+                  <address className="not-italic leading-relaxed text-slate-100">
+                    {profile.address.line1}
+                    <br />
+                    {profile.address.line2 ? (
+                      <>
+                        {profile.address.line2}
+                        <br />
+                      </>
+                    ) : null}
+                    {profile.address.city}, {profile.address.state} {profile.address.postal_code}
+                    <br />
+                    {profile.address.country}
+                  </address>
+                ) : (
+                  <p className="text-slate-500">No address on file.</p>
+                )}
+              </div>
             </div>
-            <div>
-              <p className="text-sm text-slate-400">Email</p>
-              <p className="text-lg text-slate-100">{profile.email}</p>
-            </div>
-            <div>
-              <p className="text-sm text-slate-400">Role</p>
-              <p className="text-lg text-slate-100 capitalize">{profile.role}</p>
-            </div>
-            <div>
-              <p className="text-sm text-slate-400">Address</p>
-              {profile.address ? (
-                <address className="not-italic text-slate-100">
-                  {profile.address.line1}
-                  <br />
-                  {profile.address.line2 ? (
-                    <>
-                      {profile.address.line2}
-                      <br />
-                    </>
-                  ) : null}
-                  {profile.address.city}, {profile.address.state} {profile.address.postal_code}
-                  <br />
-                  {profile.address.country}
-                </address>
-              ) : (
-                <p className="text-slate-500">No address on file.</p>
-              )}
-            </div>
-          </div>
-        ) : (
-          <p>Loading profile…</p>
-        )}
+          ) : (
+            <p className="text-slate-400">Loading profile…</p>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/web/src/state/AuthContext.js
+++ b/web/src/state/AuthContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const AuthContext = createContext(null);

--- a/web/src/state/useAuth.js
+++ b/web/src/state/useAuth.js
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { AuthContext } from './AuthContext.js';
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- overhaul the app shell with gradient backgrounds, a richer header, and a glassmorphism-inspired navigation panel
- restyle the catalog, cart, checkout, orders, profile, chat, and login pages with elevated cards, gradients, and improved typography for a cohesive experience
- refresh the vulnerability flag panel and extract the `useAuth` hook into its own module to satisfy linting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfcaf52cbc8333b48c75a44a5c9c8b