### PR TITLE
Revamp shell styling for polished experience

### DIFF
--- a/web/src/components/AppShell.jsx
+++ b/web/src/components/AppShell.jsx
@@ -7,12 +7,25 @@ function NavItem({ to, label }) {
     <NavLink
       to={to}
       className={({ isActive }) =>
-        `rounded-md px-3 py-2 text-sm font-medium transition hover:bg-slate-800 ${
-          isActive ? 'bg-slate-800 text-slate-100' : 'text-slate-300'
+        `group relative flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition duration-200 ${
+          isActive
+            ? 'bg-slate-900/90 text-white shadow-[0_16px_45px_rgba(8,15,40,0.65)] ring-1 ring-brand-accent/60'
+            : 'text-slate-300 ring-1 ring-inset ring-slate-800/70 hover:bg-slate-900/40 hover:text-white hover:ring-slate-700/70'
         }`
       }
     >
-      {label}
+      {({ isActive }) => (
+        <>
+          <span
+            className={`h-2 w-2 flex-shrink-0 rounded-full transition duration-200 ${
+              isActive
+                ? 'bg-brand-accent shadow-[0_0_0_4px_rgba(56,189,248,0.25)]'
+                : 'bg-slate-600 group-hover:bg-brand-accent/70'
+            }`}
+          />
+          <span className="truncate">{label}</span>
+        </>
+      )}
     </NavLink>
   );
 }
@@ -34,46 +47,64 @@ export default function AppShell() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100">
-      <header className="border-b border-slate-800 bg-slate-900/70">
-        <div className="mx-auto flex max-w-6xl flex-col gap-2 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <p className="text-lg font-semibold">Vulnerable AI Demo Shop</p>
-            <p className="text-xs text-slate-400">We automate our own downfall.</p>
-          </div>
-          <div className="flex items-center gap-4">
+    <div className="relative min-h-screen overflow-hidden text-slate-100">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute left-1/2 top-[-10%] h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-brand-accent/20 blur-3xl" />
+        <div className="absolute right-[12%] bottom-[-20%] h-72 w-72 rounded-full bg-indigo-500/20 blur-3xl" />
+        <div className="absolute left-[5%] bottom-[-15%] h-64 w-64 rounded-full bg-emerald-400/10 blur-3xl" />
+      </div>
+      <div className="relative mx-auto flex min-h-screen max-w-7xl flex-col px-4 pb-10 pt-6 sm:px-6 lg:px-10">
+        <header className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-[0_18px_60px_rgba(2,6,23,0.65)] backdrop-blur">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.5em] text-brand-accent">Concierge Ops</p>
+              <p className="text-2xl font-semibold text-white">Vulnerable AI Demo Shop</p>
+              <p className="max-w-xl text-sm text-slate-400">
+                We automate our own downfall. Explore the catalog, break the concierge, and discover how resilient your agents really are.
+              </p>
+            </div>
             {user ? (
-              <div className="text-right text-xs text-slate-400">
-                <p className="font-semibold text-slate-100">{user.full_name}</p>
-                <p className="uppercase tracking-wide">{user.role}</p>
+              <div className="flex flex-col gap-3 text-sm text-slate-300 sm:flex-row sm:items-center">
+                <div className="rounded-2xl border border-slate-800/70 bg-slate-950/60 px-4 py-3 text-left shadow-inner">
+                  <p className="text-xs font-medium uppercase tracking-wide text-slate-400">Signed in as</p>
+                  <p className="text-sm font-semibold text-white">{user.full_name}</p>
+                  <p className="text-xs uppercase tracking-wide text-brand-accent/80">{user.role}</p>
+                </div>
+                <button
+                  onClick={logout}
+                  className="inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-brand-accent via-sky-300 to-emerald-300 px-5 py-2 text-sm font-semibold text-slate-900 shadow-[0_16px_35px_rgba(56,189,248,0.35)] transition hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-brand-accent/70"
+                >
+                  Logout
+                </button>
               </div>
             ) : null}
-            {user ? (
-              <button
-                onClick={logout}
-                className="rounded-md border border-slate-700 px-3 py-1 text-sm text-slate-300 transition hover:bg-slate-800"
-              >
-                Logout
-              </button>
-            ) : null}
           </div>
+        </header>
+        <div className="mt-8 flex flex-1 flex-col gap-6 lg:flex-row">
+          <nav className="lg:w-72">
+            <div className="sticky top-8 space-y-4 rounded-3xl border border-slate-800/70 bg-slate-900/50 p-5 shadow-[0_12px_45px_rgba(2,6,23,0.55)] backdrop-blur">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Navigation</p>
+              <div className="flex flex-col gap-2">
+                {navItems.map((item) => (
+                  <NavItem key={item.to} to={item.to} label={item.label} />
+                ))}
+              </div>
+            </div>
+          </nav>
+          <main className="flex-1">
+            <div className="rounded-3xl border border-slate-800/60 bg-slate-900/50 p-6 shadow-[0_18px_60px_rgba(2,6,23,0.55)] backdrop-blur">
+              <Outlet />
+            </div>
+            <div className="mt-6 lg:hidden">
+              <FlagPanel dense />
+            </div>
+          </main>
+          <aside className="hidden w-80 flex-shrink-0 lg:block">
+            <div className="sticky top-8">
+              <FlagPanel />
+            </div>
+          </aside>
         </div>
-      </header>
-      <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-6 lg:flex-row">
-        <nav className="flex flex-wrap gap-2 lg:w-64 lg:flex-col">
-          {navItems.map((item) => (
-            <NavItem key={item.to} to={item.to} label={item.label} />
-          ))}
-        </nav>
-        <main className="flex-1">
-          <Outlet />
-          <div className="mt-6 lg:hidden">
-            <FlagPanel dense />
-          </div>
-        </main>
-        <aside className="hidden w-64 flex-shrink-0 lg:block">
-          <FlagPanel />
-        </aside>
       </div>
     </div>
   );

--- a/web/src/components/FlagPanel.jsx
+++ b/web/src/components/FlagPanel.jsx
@@ -20,13 +20,27 @@ export default function FlagPanel({ dense = false }) {
     return map;
   }, [flags]);
 
-  const containerClasses = `${dense ? 'space-y-3' : 'space-y-4'} rounded-lg border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300`;
+  const progressPercent = Math.min(100, Math.round((flags.length / FLAG_DEFS.length) * 100));
+  const containerClasses = `${
+    dense ? 'space-y-4 rounded-2xl p-4' : 'space-y-5 rounded-3xl p-6'
+  } border border-slate-800/70 bg-slate-900/55 text-sm text-slate-300 shadow-[0_16px_45px_rgba(2,6,23,0.45)] backdrop-blur`;
 
   return (
     <div className={containerClasses}>
-      <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-slate-100">Vulnerability Flags</h2>
-        <span className="rounded bg-slate-800 px-2 py-0.5 text-xs text-slate-400">{flags.length}/6</span>
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-white">Vulnerability Flags</h2>
+          <p className="text-xs uppercase tracking-wide text-slate-500">Gamify your chaos engineering</p>
+        </div>
+        <span className="rounded-full border border-slate-700/80 bg-slate-950/60 px-3 py-1 text-xs font-semibold text-brand-accent">
+          {flags.length}/{FLAG_DEFS.length}
+        </span>
+      </div>
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-800/80">
+        <span
+          className="block h-full rounded-full bg-gradient-to-r from-brand-accent via-sky-300 to-emerald-300"
+          style={{ width: `${Math.max(progressPercent, flags.length ? 12 : 0)}%` }}
+        />
       </div>
       <ul className="space-y-3">
         {FLAG_DEFS.map((flag) => {
@@ -34,27 +48,31 @@ export default function FlagPanel({ dense = false }) {
           return (
             <li
               key={flag.code}
-              className={`rounded border ${
-                unlocked ? 'border-emerald-700/60 bg-emerald-900/20' : 'border-slate-800 bg-slate-900/40'
-              } p-3`}
+              className={`group rounded-2xl border p-4 transition ${
+                unlocked
+                  ? 'border-emerald-500/40 bg-emerald-500/10 shadow-[0_12px_35px_rgba(16,185,129,0.25)]'
+                  : 'border-slate-800/80 bg-slate-950/40 hover:border-slate-700/70 hover:bg-slate-900/40'
+              }`}
             >
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <p className="text-sm font-semibold text-slate-100">
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold text-white">
                     {flag.code} · {flag.label}
                   </p>
                   <p className="text-xs text-slate-400">{flag.description}</p>
                 </div>
                 <span
-                  className={`rounded px-2 py-0.5 text-xs ${
-                    unlocked ? 'bg-emerald-500/20 text-emerald-200' : 'bg-slate-800 text-slate-500'
+                  className={`rounded-full px-2.5 py-1 text-[10px] font-semibold tracking-wide ${
+                    unlocked
+                      ? 'bg-emerald-400/20 text-emerald-200 shadow-[0_0_20px_rgba(16,185,129,0.35)]'
+                      : 'bg-slate-800/80 text-slate-500'
                   }`}
                 >
                   {unlocked ? 'UNLOCKED' : 'LOCKED'}
                 </span>
               </div>
               {unlocked ? (
-                <code className="mt-2 block break-all rounded bg-slate-950/70 px-2 py-1 text-xs text-emerald-200">
+                <code className="mt-3 block break-all rounded-xl bg-slate-950/80 px-3 py-2 text-[11px] text-emerald-200">
                   {awardedMap.get(flag.code)}
                 </code>
               ) : null}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -3,9 +3,19 @@
 @tailwind utilities;
 
 body {
-  @apply bg-slate-950 text-slate-100 min-h-screen;
+  @apply min-h-screen bg-slate-950 text-slate-100 antialiased;
+  background-image: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.12), transparent 45%),
+    radial-gradient(circle at 80% 10%, rgba(129, 140, 248, 0.1), transparent 55%),
+    radial-gradient(circle at 20% 90%, rgba(45, 212, 191, 0.08), transparent 50%),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.95), rgba(2, 6, 23, 0.98));
+  background-attachment: fixed;
 }
 
 #root {
   @apply min-h-screen;
+}
+
+::selection {
+  background-color: theme('colors.brand.accent');
+  color: theme('colors.slate.950');
 }

--- a/web/src/pages/CatalogPage.jsx
+++ b/web/src/pages/CatalogPage.jsx
@@ -54,19 +54,31 @@ export default function CatalogPage() {
 
   const gridContent = useMemo(() => {
     if (loading) {
-      return <p className="text-slate-400">Loading catalog…</p>;
+      return (
+        <div className="flex items-center gap-3 text-sm text-slate-400">
+          <span className="h-2.5 w-2.5 animate-pulse rounded-full bg-brand-accent/60" /> Syncing catalog…
+        </div>
+      );
     }
 
     if (error) {
-      return <p className="text-orange-400">{error}</p>;
+      return (
+        <div className="rounded-3xl border border-orange-500/50 bg-orange-500/10 p-5 text-sm text-orange-100 shadow-[0_18px_45px_rgba(194,65,12,0.35)]">
+          {error}
+        </div>
+      );
     }
 
     if (!products.length) {
-      return <p className="text-slate-500">No products seeded yet. Did the database initialise?</p>;
+      return (
+        <div className="rounded-3xl border border-slate-800/70 bg-slate-950/50 p-6 text-sm text-slate-300 shadow-inner">
+          No products seeded yet. Did the database initialise?
+        </div>
+      );
     }
 
     return (
-      <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+      <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
         {products.map((product) => {
           const basePrice = formatter.format(product.price_cents / 100);
           const variants = product.variants || [];
@@ -78,19 +90,22 @@ export default function CatalogPage() {
           return (
             <article
               key={product.id}
-              className="flex h-full flex-col justify-between rounded-lg border border-slate-800 bg-slate-900/60 p-5 text-slate-200 shadow-lg"
+              className="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-950/40 p-6 text-slate-200 shadow-[0_20px_50px_rgba(2,6,23,0.6)] transition duration-200 hover:-translate-y-1 hover:border-brand-accent/40 hover:shadow-[0_30px_70px_rgba(8,15,40,0.65)]"
             >
-              <div className="space-y-3">
-                <p className="text-xs uppercase tracking-wide text-slate-500">{product.category}</p>
-                <h2 className="text-xl font-semibold text-slate-100">{product.name}</h2>
-                <p className="text-sm text-slate-400">{product.description}</p>
+              <div className="absolute inset-x-6 top-0 h-px bg-gradient-to-r from-transparent via-brand-accent/60 to-transparent opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
+              <div className="space-y-4">
+                <span className="inline-flex items-center rounded-full border border-brand-accent/40 bg-brand-accent/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-brand-accent">
+                  {product.category}
+                </span>
+                <h2 className="text-2xl font-semibold text-white">{product.name}</h2>
+                <p className="text-sm leading-relaxed text-slate-400">{product.description}</p>
               </div>
-              <div className="mt-4 space-y-3">
+              <div className="mt-6 space-y-4">
                 {variants.length ? (
                   <label className="block text-sm text-slate-300">
-                    Variant
+                    <span className="text-xs font-medium uppercase tracking-wide text-slate-400">Variant</span>
                     <select
-                      className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-slate-100 focus:border-brand-accent focus:outline-none"
+                      className="mt-2 w-full rounded-2xl border border-slate-800/80 bg-slate-950/70 px-3 py-2 text-sm text-white focus:border-brand-accent focus:outline-none focus:ring-2 focus:ring-brand-accent/40"
                       value={selectedVariants[product.id] ?? ''}
                       onChange={(event) => handleVariantChange(product.id, event.target.value)}
                     >
@@ -102,14 +117,17 @@ export default function CatalogPage() {
                     </select>
                   </label>
                 ) : null}
-                <div className="flex items-center justify-between">
+                <div className="flex flex-wrap items-end justify-between gap-4">
                   <div>
-                    <p className="text-xs text-slate-500">Price</p>
-                    <p className="text-lg font-semibold text-slate-100">{finalPrice}</p>
+                    <p className="text-xs uppercase tracking-wide text-slate-500">Price</p>
+                    <p className="text-2xl font-semibold text-white">{finalPrice}</p>
+                    {activeVariant ? (
+                      <p className="text-xs text-slate-500">Includes {activeVariant.name} adjustment.</p>
+                    ) : null}
                   </div>
                   <button
                     onClick={() => addToCart(product)}
-                    className="rounded-md bg-brand-accent px-3 py-2 text-sm font-semibold text-slate-900 transition hover:bg-sky-300"
+                    className="inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-brand-accent via-sky-300 to-emerald-300 px-4 py-2 text-sm font-semibold text-slate-900 shadow-[0_16px_35px_rgba(56,189,248,0.35)] transition hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-brand-accent/60"
                   >
                     Add to cart
                   </button>
@@ -122,20 +140,39 @@ export default function CatalogPage() {
     );
   }, [products, selectedVariants, loading, error, addToCart]);
 
+  const productCountLabel = loading
+    ? 'Syncing inventory…'
+    : products.length
+      ? `${products.length} product${products.length === 1 ? '' : 's'}`
+      : 'Awaiting seeding…';
+  const productCountSubcopy = error ? 'Stock fetch encountered an issue.' : 'Stay curious, stay cautious.';
+
   return (
     <div className="space-y-6">
-      <header className="space-y-1">
-        <h1 className="text-3xl font-semibold text-slate-100">Product Catalog</h1>
-        <p className="text-sm text-slate-400">
-          Whimsical merch with equally whimsical vulnerabilities. Ask the concierge for help - or exploitation tips.
+      <header className="space-y-4">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div className="space-y-2">
+            <span className="inline-flex items-center rounded-full border border-brand-accent/40 bg-brand-accent/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-brand-accent">
+              Product catalog
+            </span>
+            <h1 className="text-3xl font-semibold text-white">Curated curiosities for reckless agents</h1>
+          </div>
+          <div className="rounded-2xl border border-slate-800/70 bg-slate-950/60 px-4 py-3 text-right text-xs text-slate-400 shadow-inner">
+            <p className="text-sm font-semibold text-slate-200">{productCountLabel}</p>
+            <p className="uppercase tracking-wide text-slate-500">{productCountSubcopy}</p>
+          </div>
+        </div>
+        <p className="max-w-2xl text-sm leading-relaxed text-slate-400">
+          Whimsical merch with equally whimsical vulnerabilities. Let the concierge guide you—or misguide you—through every risky
+          purchase.
         </p>
       </header>
       {feedback ? (
         <div
-          className={`rounded-md border px-4 py-2 text-sm ${
+          className={`rounded-2xl border px-4 py-3 text-sm shadow-[0_14px_40px_rgba(2,6,23,0.5)] backdrop-blur ${
             feedback.type === 'success'
-              ? 'border-emerald-700/50 bg-emerald-900/20 text-emerald-200'
-              : 'border-orange-700/60 bg-orange-900/20 text-orange-200'
+              ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-100'
+              : 'border-orange-500/50 bg-orange-500/10 text-orange-100'
           }`}
         >
           {feedback.message}

--- a/web/src/pages/CheckoutPage.jsx
+++ b/web/src/pages/CheckoutPage.jsx
@@ -77,7 +77,7 @@ export default function CheckoutPage() {
         <div className="rounded-md border border-emerald-700/50 bg-emerald-900/20 px-4 py-2 text-sm text-emerald-200">
           {success}
           <button className="ml-3 underline" onClick={() => navigate('/orders')} type="button">
-            View orders ->
+            View orders →
           </button>
         </div>
       ) : null}

--- a/web/src/state/AuthContext.jsx
+++ b/web/src/state/AuthContext.jsx
@@ -74,7 +74,7 @@ export function AuthProvider({ children }) {
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
-
+// eslint-disable-next-line react-refresh/only-export-components
 export function useAuth() {
   const ctx = useContext(AuthContext);
   if (!ctx) {


### PR DESCRIPTION
## Summary
- refresh the global shell with layered gradients, glassmorphism, and a richer navigation treatment
- modernize the vulnerability flag panel and catalog page cards with improved typography, feedback, and interactive styling
- apply minor polish fixes including checkout copy tweaks and lint rule silencing for the shared auth hook

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cfcaf52cbc8333b48c75a44a5c9c8b